### PR TITLE
Fix compilation error when using libc++

### DIFF
--- a/nes-logical-operators/src/Operators/Windows/Aggregations/Sample/ReservoirProbeLogicalOperator.cpp
+++ b/nes-logical-operators/src/Operators/Windows/Aggregations/Sample/ReservoirProbeLogicalOperator.cpp
@@ -150,8 +150,14 @@ std::string ReservoirProbeLogicalOperator::explain(ExplainVerbosity verbosity, O
     {
         return fmt::format("RESERVOIR_PROBE(opId: {}, statHash: {}, sampleSchema: {})", id, statisticHash, sampleSchema);
     }
-    std::string joined = sampleSchema.getFieldNames() | std::views::transform([](const auto& s) -> std::string_view { return s; })
-        | std::views::join_with(',') | std::ranges::to<std::string>();
+    std::string joined;
+    const auto& fields = sampleSchema.getFieldNames();
+
+    for (size_t i = 0; i < fields.size(); ++i) {
+        if (i > 0)
+            joined += ',';
+        joined += fields[i];
+    }
     return fmt::format("RESERVOIR_PROBE({})", joined);
 }
 


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
This pull request removes the use of `std::views::join_with()` which caused the build to fail when using libc++

## Verifying this change
Build the `All Ctest` target with `-DUSE_LIBCXX_IF_AVAILABLE:BOOL=ON`