### PR TITLE
feat(GeneratorSource): Add ALTERNATING Generator mode

### DIFF
--- a/nes-plugins/Sources/GeneratorSource/Generator.cpp
+++ b/nes-plugins/Sources/GeneratorSource/Generator.cpp
@@ -123,6 +123,10 @@ void Generator::parseRawSchemaLine(std::string_view line)
             this->addField(std::make_unique<GeneratorFields::GeneratorFieldType>(GeneratorFields::RandomStrField(line)));
             break;
         }
+        case GeneratorFields::FieldIdentifier::ALTERNATING: {
+            this->addField(std::make_unique<GeneratorFields::GeneratorFieldType>(GeneratorFields::AlternatingField(line)));
+            break;
+        }
         default: {
             throw InvalidConfigParameter("Invalid line, {} is not a recognized generatorType: {}", firstWord, line);
         }

--- a/nes-plugins/Sources/GeneratorSource/GeneratorFields.cpp
+++ b/nes-plugins/Sources/GeneratorSource/GeneratorFields.cpp
@@ -20,6 +20,7 @@
 #include <fstream>
 #include <iomanip>
 #include <ios>
+#include <optional>
 #include <ostream>
 #include <random>
 #include <ranges>
@@ -263,6 +264,51 @@ std::ostream& SequenceField::generate(std::ostream& os, std::mt19937& /*re*/)
 
 namespace
 {
+/// Parses a single value as T and wraps it in a FieldType, or returns nullopt if it does not fit T.
+template <typename T>
+std::optional<FieldType> parseAs(std::string_view value)
+{
+    if (const auto parsed = from_chars<T>(value))
+    {
+        return FieldType{*parsed};
+    }
+    return std::nullopt;
+}
+
+/// Parses a `value` as the C++ type `type`, returning nullopt on parse failure or unsupported type.
+std::optional<FieldType> tryParseBound(const DataType::Type type, std::string_view value)
+{
+    switch (type)
+    {
+        case DataType::Type::UINT8:
+            return parseAs<uint8_t>(value);
+        case DataType::Type::UINT16:
+            return parseAs<uint16_t>(value);
+        case DataType::Type::UINT32:
+            return parseAs<uint32_t>(value);
+        case DataType::Type::UINT64:
+            return parseAs<uint64_t>(value);
+        case DataType::Type::INT8:
+            return parseAs<int8_t>(value);
+        case DataType::Type::INT16:
+            return parseAs<int16_t>(value);
+        case DataType::Type::INT32:
+            return parseAs<int32_t>(value);
+        case DataType::Type::INT64:
+            return parseAs<int64_t>(value);
+        case DataType::Type::FLOAT32:
+            return parseAs<float>(value);
+        case DataType::Type::FLOAT64:
+            return parseAs<double>(value);
+        case DataType::Type::BOOLEAN:
+        case DataType::Type::CHAR:
+        case DataType::Type::VARSIZED:
+        case DataType::Type::UNDEFINED:
+            return std::nullopt;
+    }
+    return std::nullopt;
+}
+
 template <typename T, typename U = double>
 NormalDistributionField::DistributionVariant createDistribution(const std::string_view mean, const std::string_view stdDev)
 {
@@ -280,6 +326,34 @@ NormalDistributionField::DistributionVariant createDistribution(const std::strin
         return std::binomial_distribution<T>(*parsedMean, *parsedStdDev);
     }
 };
+
+template <typename T>
+void generateUniformValue(
+    std::ostream& os, std::mt19937& randEng, const GeneratorFields::FieldType& minField, const GeneratorFields::FieldType& maxField)
+{
+    const auto lo = std::get<T>(minField);
+    const auto hi = std::get<T>(maxField);
+    if constexpr (std::is_floating_point_v<T>)
+    {
+        std::uniform_real_distribution<T> dist(lo, hi);
+        os << dist(randEng);
+    }
+    else if constexpr (std::is_same_v<T, uint8_t>)
+    {
+        std::uniform_int_distribution<uint16_t> dist(lo, hi);
+        os << static_cast<int32_t>(static_cast<T>(dist(randEng)));
+    }
+    else if constexpr (std::is_same_v<T, int8_t>)
+    {
+        std::uniform_int_distribution<int16_t> dist(lo, hi);
+        os << static_cast<int32_t>(static_cast<T>(dist(randEng)));
+    }
+    else
+    {
+        std::uniform_int_distribution<T> dist(lo, hi);
+        os << dist(randEng);
+    }
+}
 }
 
 NormalDistributionField::NormalDistributionField(const std::string_view rawSchemaLine)
@@ -565,6 +639,131 @@ std::ostream& RandomStrField::generate(std::ostream& os, std::mt19937& randEng)
     for (size_t i = 0; i < randomLength; i++)
     {
         os << randomAlphabetChar();
+    }
+    return os;
+}
+
+AlternatingField::AlternatingField(std::string_view rawSchemaLine)
+{
+    const auto parameters = splitWithStringDelimiter<std::string_view>(rawSchemaLine, " ");
+    const auto type = parameters[1];
+    const auto dataType = DataTypeProvider::tryProvideDataType(std::string{type});
+    INVARIANT(dataType.has_value(), "Invalid AlternatingField type of {}!", type);
+    outputType = dataType.value();
+
+    const auto parsedCount = from_chars<std::size_t>(parameters[2]);
+    INVARIANT(parsedCount.has_value(), "Invalid AlternatingField count_per_phase: {}", parameters[2]);
+    countPerPhase = *parsedCount;
+
+    for (std::size_t i = 3; i < NUM_PARAMETERS_ALTERNATING_FIELD; i += 2)
+    {
+        auto lo = tryParseBound(outputType.type, parameters[i]);
+        auto hi = tryParseBound(outputType.type, parameters[i + 1]);
+        INVARIANT(lo && hi, "AlternatingField: cannot parse bounds {} {} as type {}", parameters[i], parameters[i + 1], type);
+        phases.emplace_back(*lo, *hi);
+    }
+}
+
+void AlternatingField::validate(std::string_view rawSchemaLine)
+{
+    const auto parameters = splitWithStringDelimiter<std::string_view>(rawSchemaLine, " ");
+    if (parameters.size() < static_cast<std::size_t>(NUM_PARAMETERS_ALTERNATING_FIELD))
+    {
+        throw InvalidConfigParameter(
+            "AlternatingField requires at least {} parameters, got {}: {}",
+            NUM_PARAMETERS_ALTERNATING_FIELD,
+            parameters.size(),
+            rawSchemaLine);
+    }
+
+    const auto dataType = DataTypeProvider::tryProvideDataType(std::string{parameters[1]});
+    if (!dataType.has_value())
+    {
+        throw InvalidConfigParameter("Invalid AlternatingField type {}: {}", parameters[1], rawSchemaLine);
+    }
+    switch (dataType.value().type)
+    {
+        case DataType::Type::BOOLEAN:
+        case DataType::Type::CHAR:
+        case DataType::Type::VARSIZED:
+        case DataType::Type::UNDEFINED:
+            throw InvalidConfigParameter("AlternatingField does not support type {}: {}", parameters[1], rawSchemaLine);
+        default:
+            break;
+    }
+
+    const auto parsedCount = from_chars<std::size_t>(parameters[2]);
+    if (!parsedCount || *parsedCount < 1)
+    {
+        throw InvalidConfigParameter("AlternatingField count_per_phase must be >= 1: {}", rawSchemaLine);
+    }
+
+    for (std::size_t i = 3; i < NUM_PARAMETERS_ALTERNATING_FIELD; i += 2)
+    {
+        const auto minVal = tryParseBound(dataType.value().type, parameters[i]);
+        const auto maxVal = tryParseBound(dataType.value().type, parameters[i + 1]);
+        if (!minVal)
+        {
+            throw InvalidConfigParameter(
+                "AlternatingField: cannot parse min bound {} as type {}: {}", parameters[i], parameters[1], rawSchemaLine);
+        }
+        if (!maxVal)
+        {
+            throw InvalidConfigParameter(
+                "AlternatingField: cannot parse max bound {} as type {}: {}", parameters[i + 1], parameters[1], rawSchemaLine);
+        }
+        if (*minVal > *maxVal)
+        {
+            throw InvalidConfigParameter(
+                "AlternatingField: min {} > max {} in phase {}: {}", parameters[i], parameters[i + 1], (i - 3) / 2, rawSchemaLine);
+        }
+    }
+}
+
+std::ostream& AlternatingField::generate(std::ostream& os, std::mt19937& randEng)
+{
+    const auto& [minField, maxField] = phases[currentPhase];
+    switch (outputType.type)
+    {
+        case DataType::Type::UINT8:
+            generateUniformValue<uint8_t>(os, randEng, minField, maxField);
+            break;
+        case DataType::Type::UINT16:
+            generateUniformValue<uint16_t>(os, randEng, minField, maxField);
+            break;
+        case DataType::Type::UINT32:
+            generateUniformValue<uint32_t>(os, randEng, minField, maxField);
+            break;
+        case DataType::Type::UINT64:
+            generateUniformValue<uint64_t>(os, randEng, minField, maxField);
+            break;
+        case DataType::Type::INT8:
+            generateUniformValue<int8_t>(os, randEng, minField, maxField);
+            break;
+        case DataType::Type::INT16:
+            generateUniformValue<int16_t>(os, randEng, minField, maxField);
+            break;
+        case DataType::Type::INT32:
+            generateUniformValue<int32_t>(os, randEng, minField, maxField);
+            break;
+        case DataType::Type::INT64:
+            generateUniformValue<int64_t>(os, randEng, minField, maxField);
+            break;
+        case DataType::Type::FLOAT32:
+            generateUniformValue<float>(os, randEng, minField, maxField);
+            break;
+        case DataType::Type::FLOAT64:
+            generateUniformValue<double>(os, randEng, minField, maxField);
+            break;
+        default:
+            INVARIANT(false, "Unsupported outputType in AlternatingField::generate");
+    }
+
+    ++currentCount;
+    if (currentCount >= countPerPhase)
+    {
+        currentCount = 0;
+        currentPhase = (currentPhase + 1) % phases.size();
     }
     return os;
 }

--- a/nes-plugins/Sources/GeneratorSource/GeneratorFields.hpp
+++ b/nes-plugins/Sources/GeneratorSource/GeneratorFields.hpp
@@ -37,6 +37,7 @@ enum class FieldIdentifier : uint8_t
     NORMAL_DISTRIBUTION,
     WORDLIST,
     RANDOMSTR,
+    ALTERNATING,
     INVALID,
 };
 
@@ -147,8 +148,26 @@ private:
                                's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/'});
 };
 
+constexpr auto NUM_PARAMETERS_ALTERNATING_FIELD = 7;
+
+/// @brief Generates uniform random values cycling through phases, each with its own [min, max] range
+class AlternatingField final : public BaseGeneratorField
+{
+public:
+    explicit AlternatingField(std::string_view rawSchemaLine);
+    std::ostream& generate(std::ostream& os, std::mt19937& randEng) override;
+    static void validate(std::string_view rawSchemaLine);
+
+private:
+    DataType outputType;
+    std::size_t countPerPhase;
+    std::vector<std::pair<FieldType, FieldType>> phases;
+    std::size_t currentPhase{0};
+    std::size_t currentCount{0};
+};
+
 /// @brief Variant containing the types of base generator fields
-using GeneratorFieldType = std::variant<SequenceField, NormalDistributionField, WordListField, RandomStrField>;
+using GeneratorFieldType = std::variant<SequenceField, NormalDistributionField, WordListField, RandomStrField, AlternatingField>;
 
 struct FieldValidator
 {
@@ -158,11 +177,12 @@ struct FieldValidator
 
 /// @brief Array containing functions paired with the fields identifier used to validate the fields syntax
 /// NOLINTBEGIN(cert-err58-cpp): do not warn about static storage duration
-static const std::array<FieldValidator, 4> Validators = {
+static const std::array<FieldValidator, 5> Validators = {
     {{.identifier = FieldIdentifier::SEQUENCE, .validator = SequenceField::validate},
      {.identifier = FieldIdentifier::NORMAL_DISTRIBUTION, .validator = NormalDistributionField::validate},
      {.identifier = FieldIdentifier::WORDLIST, .validator = WordListField::validate},
-     {.identifier = FieldIdentifier::RANDOMSTR, .validator = RandomStrField::validate}},
+     {.identifier = FieldIdentifier::RANDOMSTR, .validator = RandomStrField::validate},
+     {.identifier = FieldIdentifier::ALTERNATING, .validator = AlternatingField::validate}},
 };
 /// NOLINTEND(cert-err58-cpp)
 
@@ -182,6 +202,16 @@ static const std::unordered_multimap<FieldIdentifier, DataType::Type> FieldNameT
        {FieldIdentifier::NORMAL_DISTRIBUTION, DataType::Type::FLOAT64},
        {FieldIdentifier::NORMAL_DISTRIBUTION, DataType::Type::FLOAT32},
        {FieldIdentifier::WORDLIST, DataType::Type::VARSIZED},
-       {FieldIdentifier::RANDOMSTR, DataType::Type::VARSIZED}};
+       {FieldIdentifier::RANDOMSTR, DataType::Type::VARSIZED},
+       {FieldIdentifier::ALTERNATING, DataType::Type::INT64},
+       {FieldIdentifier::ALTERNATING, DataType::Type::INT32},
+       {FieldIdentifier::ALTERNATING, DataType::Type::INT16},
+       {FieldIdentifier::ALTERNATING, DataType::Type::INT8},
+       {FieldIdentifier::ALTERNATING, DataType::Type::UINT64},
+       {FieldIdentifier::ALTERNATING, DataType::Type::UINT32},
+       {FieldIdentifier::ALTERNATING, DataType::Type::UINT16},
+       {FieldIdentifier::ALTERNATING, DataType::Type::UINT8},
+       {FieldIdentifier::ALTERNATING, DataType::Type::FLOAT64},
+       {FieldIdentifier::ALTERNATING, DataType::Type::FLOAT32}};
 /// NOLINTEND(cert-err58-cpp)
 }

--- a/nes-systests/sources/Generator.test
+++ b/nes-systests/sources/Generator.test
@@ -184,3 +184,37 @@ INTO generator_sink_text;
 17,yellow,X
 18,brown,bl5
 19,yellow,IgiKX
+
+# ALTERNATING field: two phases [0,5] and [5,10], count_per_phase=3
+CREATE LOGICAL SOURCE generatorAlternatingGrouped(id UINT64 NOT NULL, val UINT8 NOT NULL);
+CREATE PHYSICAL SOURCE FOR generatorAlternatingGrouped TYPE Generator SET(
+       'ONE' as `SOURCE`.STOP_GENERATOR_WHEN_SEQUENCE_FINISHES,
+       1 AS `SOURCE`.SEED,
+       'SEQUENCE UINT64 0 6 1, ALTERNATING UINT8 3 0 5 5 10' AS `SOURCE`.GENERATOR_SCHEMA
+);
+CREATE SINK generator_sink_alternating_grouped(generatorAlternatingGrouped.id UINT64 NOT NULL, generatorAlternatingGrouped.val UINT8 NOT NULL) TYPE File;
+SELECT * FROM generatorAlternatingGrouped INTO generator_sink_alternating_grouped;
+----
+0 2
+1 5
+2 4
+3 10
+4 5
+5 5
+
+# ALTERNATING field: two non-overlapping phases of floats [0,2.9], [3,5.9]
+CREATE LOGICAL SOURCE generatorAlternatingFloat(id UINT64 NOT NULL, val FLOAT32 NOT NULL);
+CREATE PHYSICAL SOURCE FOR generatorAlternatingFloat TYPE Generator SET(
+       'ONE' as `SOURCE`.STOP_GENERATOR_WHEN_SEQUENCE_FINISHES,
+       1 AS `SOURCE`.SEED,
+       'SEQUENCE UINT64 0 6 1, ALTERNATING FLOAT32 1 0.0 2.9 3.0 5.9' AS `SOURCE`.GENERATOR_SCHEMA
+);
+CREATE SINK generator_sink_alternating_float(generatorAlternatingFloat.id UINT64 NOT NULL, generatorAlternatingFloat.val FLOAT32 NOT NULL) TYPE File;
+SELECT * FROM generatorAlternatingFloat INTO generator_sink_alternating_float;
+----
+0 1.20936
+1 5.89184
+2 2.08894
+3 5.70442
+4 0.000332
+5 3.37156


### PR DESCRIPTION
## Purpose of the Change and Brief Change Log
Adds a new mode called alternating to the generator source. It switches between a range of numbers each `count` tuples, eg. 0-4 for 10 tuples, then 5-10 for 10 tuples, and back to 0-4, etc.

## Verifying this change
Three new systest cases in Generator.test

## What components does this pull request potentially affect?
Anything using the GeneratorSource.

## Documentation
In the systest file.


## Issue Closed by this pull request: